### PR TITLE
use caret instead of tilde requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["flac", "audio", "parser", "metadata"]
 [dependencies]
 log = "0.3.7"
 rustc-serialize = "0.3.23"
-byteorder = "~1.0.0"
+byteorder = "1.0.0"
 num = "0.1.37"


### PR DESCRIPTION
Hi there, i was having problems using both `rust-metaflac` and `rust-id3` because both have tidle versions for different byteorder versions, and apparently cargo doesn't know how to deal with that 

```
error: failed to select a version for `byteorder` (required by `metaflac`):
all possible versions conflict with previously selected versions of `byteorder`
  version 1.1.0 in use by byteorder v1.1.0
  possible versions to select: 1.0.0
```

using caret versions fixes that, if you want you can read the conversation that when to it here : https://botbot.me/mozilla/cargo/2017-12-08/?msg=94402187&page=1 