### PR TITLE
Get rid of unecessary num dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ keywords = ["flac", "audio", "parser", "metadata"]
 log = "0.4.8"
 hex = "0.4.0"
 byteorder = "1.3.2"
-num = "0.2.0"


### PR DESCRIPTION
The `num` dependency is not used a lot, but adds a lot to the compile time. I would suggest to remove it.