### PR TITLE
Ensure STREAMINFO block is always first

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -2,7 +2,7 @@ extern crate byteorder;
 
 use self::byteorder::{BigEndian, ReadBytesExt};
 
-use block::{Block, BlockType, Picture, PictureType, VorbisComment};
+use block::{Block, BlockType, Picture, PictureType, VorbisComment, StreamInfo};
 use error::{Error, ErrorKind, Result};
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Seek, SeekFrom, Write};
@@ -31,6 +31,11 @@ impl<'a> Tag {
 
     /// Adds a block to the tag.
     pub fn push_block(&mut self, block: Block) {
+        if let Block::StreamInfo(s) = block {
+            self.set_streaminfo(s);
+            return;
+        }
+
         self.blocks.push(block);
     }
 
@@ -296,6 +301,13 @@ impl<'a> Tag {
             Block::Picture(ref picture) => picture.picture_type != picture_type,
             _ => true,
         });
+    }
+
+    
+    /// Pushes new or updates existing STREAMINFO block
+    pub fn set_streaminfo(&mut self, block: StreamInfo) {
+        self.remove_blocks(BlockType::StreamInfo);
+        self.blocks.insert(0, Block::StreamInfo(block));
     }
 
     /// Attempts to save the tag back to the file which it was read from. An `Error::InvalidInput`

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -303,7 +303,17 @@ impl<'a> Tag {
         });
     }
 
-    
+    /// Returns STREAMINFO block if exists
+    pub fn get_streaminfo(&self) -> Option<&StreamInfo> {
+        for i in 0..self.blocks.len() {
+            if let Block::StreamInfo(s) = &self.blocks[i] {
+                return Some(s);
+            }
+        }
+
+        None
+    }
+
     /// Pushes new or updates existing STREAMINFO block
     pub fn set_streaminfo(&mut self, block: StreamInfo) {
         self.remove_blocks(BlockType::StreamInfo);


### PR DESCRIPTION
StreamInfo block should always be the first block in file, otherwise it becomes unreadable by some decoders. There's also should be only one StreamInfo block in the file, so `set_streaminfo` also ensures that no other blocks are left and convenience `get_streaminfo` method is provided to get the (first) block.