### PR TITLE
Update to 2018 edition and clippy warning fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,13 @@ repository = "https://github.com/jameshurst/rust-metaflac"
 documentation = "https://jameshurst.github.io/rust-metaflac"
 description = "A library for reading and writing FLAC metadata."
 keywords = ["flac", "audio", "parser", "metadata"]
+edition = "2018"
+
+[lib]
+name = "metaflac"
+crate-type = ["rlib"]
 
 [dependencies]
-log = "0.4.8"
-hex = "0.4.0"
-byteorder = "1.3.2"
+log = "0.4.11"
+hex = "0.4.2"
+byteorder = "^1.3.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,8 @@ impl fmt::Debug for Error {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         if self.description != "" {
             write!(out, "{:?}: {}", self.kind, self.description)
+        } else if let Some(source) = error::Error::source(self) {
+            write!(out, "{}", source)
         } else {
             write!(out, "{:?}", self.kind)
         }
@@ -75,6 +77,8 @@ impl fmt::Display for Error {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         if self.description != "" {
             write!(out, "{:?}: {}", self.kind, self.description)
+        } else if let Some(source) = error::Error::source(self) {
+            write!(out, "{}", source)
         } else {
             write!(out, "{:?}", self.kind)
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,3 @@
-extern crate byteorder;
-
 use std::error;
 use std::fmt;
 use std::io;
@@ -31,27 +29,12 @@ pub struct Error {
 impl Error {
     /// Creates a new `Error` using the error kind and description.
     pub fn new(kind: ErrorKind, description: &'static str) -> Error {
-        Error {
-            kind: kind,
-            description: description,
-        }
+        Error { kind, description }
     }
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        if self.source().is_some() {
-            self.source().unwrap().description()
-        } else {
-            match self.kind {
-                ErrorKind::Io(ref err) => error::Error::description(err),
-                ErrorKind::StringDecoding(ref err) => err.description(),
-                _ => self.description,
-            }
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self.kind {
             ErrorKind::Io(ref err) => Some(err),
             ErrorKind::StringDecoding(ref err) => Some(err),
@@ -81,9 +64,9 @@ impl From<string::FromUtf8Error> for Error {
 impl fmt::Debug for Error {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         if self.description != "" {
-            write!(out, "{:?}: {}", self.kind, error::Error::description(self))
+            write!(out, "{:?}: {}", self.kind, self.description)
         } else {
-            write!(out, "{}", error::Error::description(self))
+            write!(out, "{:?}", self.kind)
         }
     }
 }
@@ -91,9 +74,9 @@ impl fmt::Debug for Error {
 impl fmt::Display for Error {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         if self.description != "" {
-            write!(out, "{:?}: {}", self.kind, error::Error::description(self))
+            write!(out, "{:?}: {}", self.kind, self.description)
         } else {
-            write!(out, "{}", error::Error::description(self))
+            write!(out, "{:?}", self.kind)
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,23 @@ impl error::Error for Error {
             _ => None,
         }
     }
+
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        if self.source().is_some() {
+            self.source().unwrap().description()
+        } else {
+            match self.kind {
+                ErrorKind::Io(ref err) => error::Error::description(err),
+                ErrorKind::StringDecoding(ref err) => err.description(),
+                _ => self.description,
+            }
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        error::Error::source(self)
+    }
 }
 
 impl From<io::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! A library to read and write FLAC metadata tags.
 
-#![crate_name = "metaflac"]
-#![crate_type = "rlib"]
 #![warn(missing_docs)]
 
 #[macro_use]


### PR DESCRIPTION
This PR:
- Updates to the 2018 edition
- Updates the dependencies
- Fixes clippy warnings
- Removes use of deprecated functions
- Simplifies some documentation code examples
- Runs cargo fmt on the repo
