### PR TITLE
Fix overwriting existing ID3 tags

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1224,7 +1224,9 @@ where
     }
 }
 
-fn read_ident<R: Read>(mut reader: R) -> Result<()> {
+/// Read from a reader until a flac file identifier is found. Returns an error if no flac identifier
+/// could be found.
+pub fn read_ident<R: Read>(mut reader: R) -> Result<()> {
     use std::io;
 
     let mut ident = [0; 4];

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -460,8 +460,9 @@ impl<'a> Tag {
             debug!("Writing using padding");
             let mut file = OpenOptions::new()
                 .write(true)
+                .read(true)
                 .open(self.path.as_ref().unwrap())?;
-            file.seek(SeekFrom::Start(4))?;
+            crate::block::read_ident(&mut file)?;
 
             for bytes in block_bytes.iter() {
                 file.write_all(&bytes[..])?;


### PR DESCRIPTION
When reading tags from a flac file with an ID3 tag in the beginning, `metaflac` correctly skips the ID3 tag (since #14). But when trying to write back a changed tag to the same flac file, `metaflac` just skips 4 bytes of the file and starts writing, thus overwriting the existing ID3 tag without removing the header. The `fLaC` identifier is also overwritten making the entire resulting file corrupt.

This PR fixes that by searching for the `fLaC` identifier before writing a tag back to the file thus leaving any existing ID3 tag unchanged.